### PR TITLE
Support longer chart time ranges for high-frequency CGMs via configurable API limit and date filtering

### DIFF
--- a/GlucoseBar/Chart/GraphView.swift
+++ b/GlucoseBar/Chart/GraphView.swift
@@ -38,27 +38,26 @@ struct GraphView: View {
         var data: [GraphEntry] = [];
         if let entries = g.entries {
 
-            let entryCount = s.graphMinutes/5-1
+            let cutoff = Date(timeIntervalSinceNow: -Double(s.graphMinutes) * 60)
 
-            for i in 0..<entryCount {
-                if (entries.count > i) {
-                    let entry = entries[i]
-                    let glu = convertGlucose(s, glucose: entry.glucose)
+            for entry in entries {
+                if entry.date < cutoff { continue }
 
-                    var delta = 0.0
-                    if let changeRate = entry.changeRate {
-                        delta = changeRate
-                    }
+                let glu = convertGlucose(s, glucose: entry.glucose)
 
-                    var glucoseTarget = s.glucoseTarget
-                    if let fetchedGlucoseTarget = g.provider.GlucoseSourceExtras.glucoseTarget {
-                        glucoseTarget = fetchedGlucoseTarget
-                    }
-
-                    let color = getDynamicGlucoseColor(glucoseValue: Decimal(convertGlucose(s, glucose: entry.glucose)), highGlucoseColorValue: highThresholdRuleMark, lowGlucoseColorValue: lowThresholdRuleMark, targetGlucose: Decimal(convertGlucose(s, glucose: glucoseTarget)), glucoseColorScheme: s.glucoseColorScheme)
-
-                    data.append(GraphEntry(date: entry.date, value: glu, trend: entry.trend ?? .notComputable, delta: delta, color: color, forecastType: .none, glucoseType: entry.glucoseType))
+                var delta = 0.0
+                if let changeRate = entry.changeRate {
+                    delta = changeRate
                 }
+
+                var glucoseTarget = s.glucoseTarget
+                if let fetchedGlucoseTarget = g.provider.GlucoseSourceExtras.glucoseTarget {
+                    glucoseTarget = fetchedGlucoseTarget
+                }
+
+                let color = getDynamicGlucoseColor(glucoseValue: Decimal(convertGlucose(s, glucose: entry.glucose)), highGlucoseColorValue: highThresholdRuleMark, lowGlucoseColorValue: lowThresholdRuleMark, targetGlucose: Decimal(convertGlucose(s, glucose: glucoseTarget)), glucoseColorScheme: s.glucoseColorScheme)
+
+                data.append(GraphEntry(date: entry.date, value: glu, trend: entry.trend ?? .notComputable, delta: delta, color: color, forecastType: .none, glucoseType: entry.glucoseType))
             }
         }
 

--- a/GlucoseBar/Glucose.swift
+++ b/GlucoseBar/Glucose.swift
@@ -114,7 +114,7 @@ class Glucose: ObservableObject, Sendable {
             case .dexcomshare:
             provider = DexcomShare(username: settings.dxEmail, password: settings.dxPassword, server: settings.dxServer)
         case .nightscout:
-            provider = Nightscout(baseURL: settings.nsURL, token: settings.nsSecret, aidEnabled: settings.aidEnableIntegration)
+            provider = Nightscout(baseURL: settings.nsURL, token: settings.nsSecret, aidEnabled: settings.aidEnableIntegration, apiLimit: settings.nsAPILimit)
         default:
             provider = Simulator("defaulted")
         }
@@ -129,6 +129,14 @@ class Glucose: ObservableObject, Sendable {
             notificationCenter.removeObserver(observer)
         }
         registerForNotifications()
+
+        // Trigger immediate fetch for quick feedback after settings change
+        Task {
+            self.isFetching = true
+            await self.provider.fetch()
+            self.isFetching = false
+            self.getGlucose()
+        }
 
         self.logger.notice("Reset glucose object")
     }
@@ -156,7 +164,7 @@ class Glucose: ObservableObject, Sendable {
             DispatchQueue.main.async {
                 switch settings.cgmProvider {
                 case .nightscout:
-                    self.provider = Nightscout(baseURL: settings.nsURL, token: settings.nsSecret, aidEnabled: settings.aidEnableIntegration)
+                    self.provider = Nightscout(baseURL: settings.nsURL, token: settings.nsSecret, aidEnabled: settings.aidEnableIntegration, apiLimit: settings.nsAPILimit)
                 case .dexcomshare:
                     self.provider = DexcomShare(username: settings.dxEmail, password: settings.dxPassword, server: settings.dxServer)
                 case .simulator:

--- a/GlucoseBar/Localizable.xcstrings
+++ b/GlucoseBar/Localizable.xcstrings
@@ -711,6 +711,28 @@
         }
       }
     },
+    "API Limit" : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "API-grænse"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API Limit"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Limite API"
+          }
+        }
+      }
+    },
     "Are you sure you want to remove data for %@?" : {
       "localizations" : {
         "da" : {
@@ -1486,6 +1508,29 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Erreur"
+          }
+        }
+      }
+    },
+    "Error from Nightscout: %@" : {
+      "comment" : "Generic error from Nightscout server",
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fejl fra Nightscout: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error from Nightscout: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Erreur de Nightscout : %@"
           }
         }
       }
@@ -2421,6 +2466,28 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Valeur max."
+          }
+        }
+      }
+    },
+    "Maximum entries per request. Default is 1000, which is the standard Nightscout server limit (API3_MAX_LIMIT). Increase only if your server admin has raised this limit. Useful for longer time ranges (12h, 24h) on CGMs with frequent readings. The value is validated when you save or test the connection." : {
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Maksimalt antal poster per forespørgsel. Standard er 1000, som er den normale Nightscout-servergrænse (API3_MAX_LIMIT). Øg kun hvis din serveradministrator har hævet denne grænse. Nyttigt for længere tidsintervaller (12t, 24t) på CGM'er med hyppige aflæsninger. Værdien valideres når du gemmer eller tester forbindelsen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum entries per request. Default is 1000, which is the standard Nightscout server limit (API3_MAX_LIMIT). Increase only if your server admin has raised this limit. Useful for longer time ranges (12h, 24h) on CGMs with frequent readings. The value is validated when you save or test the connection."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nombre maximum d'entrées par requête. La valeur par défaut est 1000, qui est la limite standard du serveur Nightscout (API3_MAX_LIMIT). N'augmentez que si l'administrateur de votre serveur a relevé cette limite. Utile pour des plages horaires plus longues (12h, 24h) sur les CGM avec des lectures fréquentes. La valeur est validée lorsque vous enregistrez ou testez la connexion."
           }
         }
       }
@@ -3554,6 +3621,29 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "La cible est utilisée pour colorier correctement les valeurs de glycémie dans le graphique lorsque vous l'avez configuré pour utiliser des couleurs dynamiques."
+          }
+        }
+      }
+    },
+    "The API Limit (%lld) exceeds your server's maximum. Try a lower value." : {
+      "comment" : "Error when Nightscout rejects the configured API entry limit",
+      "localizations" : {
+        "da" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "API-grænsen (%lld) overstiger din servers maksimum. Prøv en lavere værdi."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The API Limit (%lld) exceeds your server's maximum. Try a lower value."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "La limite API (%lld) dépasse le maximum de votre serveur. Essayez une valeur inférieure."
           }
         }
       }

--- a/GlucoseBar/Providers/Nightscout/Nightscout.swift
+++ b/GlucoseBar/Providers/Nightscout/Nightscout.swift
@@ -21,8 +21,9 @@ class Nightscout: Provider, @unchecked Sendable {
     var baseURL: String
     var token: String
     var aidEnabled: Bool
+    var apiLimit: Int
 
-    init(baseURL: String, token: String, aidEnabled: Bool) {
+    init(baseURL: String, token: String, aidEnabled: Bool, apiLimit: Int = 1000) {
 
         // Do some basic validation
         if baseURL.isEmpty {
@@ -38,6 +39,7 @@ class Nightscout: Provider, @unchecked Sendable {
         self.baseURL = baseURL
         self.token = token
         self.aidEnabled = aidEnabled
+        self.apiLimit = apiLimit
 
         if baseURL.hasSuffix("/") {
             self.baseURL = String(self.baseURL.dropLast())
@@ -89,21 +91,25 @@ class Nightscout: Provider, @unchecked Sendable {
 
         self.providerIssue = nil
 
-        var url = "\(baseURL)/api/v3/entries?sort%24desc=date&fields=sgv%2Ctrend%2Cdirection%2Cdate%2Cidentifier"
+        // Fetch entries from the last 24 hours using a date filter so the chart can display up to 24h.
+        // The Nightscout API v3 default max limit is 1000 (API3_MAX_LIMIT). Users can configure this
+        // in Settings if their server admin has raised the limit.
+        let dateCutoff = Int(Date(timeIntervalSinceNow: -86400).timeIntervalSince1970 * 1000)
+        var url = "\(baseURL)/api/v3/entries?sort%24desc=date&fields=sgv%2Ctrend%2Cdirection%2Cdate%2Cidentifier&date%24gte=\(dateCutoff)"
 
-        var limit = 288
+        var limit = self.apiLimit
         if self.GlucoseEntries.count > 1 {
             limit = 1
             logger.info("Time since last fetch: \(self.lastFetch.timeIntervalSinceNow * -1, privacy: .public) seconds")
             if self.lastFetch.timeIntervalSinceNow < -400 {
                 logger.info("re-setting limit to full fetch because last fetch was more than 400 seconds ago")
-                limit = 288
+                limit = self.apiLimit
             }
 
             // This is a workaround for avoiding gaps in the graph. A better solution should be found so we don't tax the NS server unnecessarily every 15 minutes.
             if self.lastFullFetch.timeIntervalSinceNow < -900 {
                 logger.info("full fetch because it's been over 15 minutes since we got all data")
-                limit = 288
+                limit = self.apiLimit
                 self.lastFullFetch = Date()
             }
 
@@ -162,7 +168,7 @@ class Nightscout: Provider, @unchecked Sendable {
                             var updatedEntries = currentEntries
                             updatedEntries.insert(contentsOf: newEntries, at: 0)
 
-                            if updatedEntries.count > 288 {
+                            if updatedEntries.count > self.apiLimit {
                                 self.logger.debug("removing entry from glucoseentries: \(updatedEntries.last!.glucose, privacy: .private)")
                                 updatedEntries.removeLast()
                             }
@@ -211,11 +217,17 @@ class Nightscout: Provider, @unchecked Sendable {
                 await self.fetch()
                 return
             } else {
+                self.logger.error("Nightscout entries request failed with status \(res!.statusCode, privacy: .public)")
                 do {
                     let result = try JSONDecoder().decode(NightscoutEntriesErrorResponse.self, from: data)
+                    self.logger.error("Nightscout error message: \(result.message, privacy: .public)")
                     DispatchQueue.main.async { [weak self] in
                         guard let self = self else { return }
-                        self.providerIssue = "Error from Nightscout: \(result.message)"
+                        if result.message.lowercased().contains("limit") || result.message.lowercased().contains("tolerance") {
+                            self.providerIssue = String(localized: "The API Limit (\(self.apiLimit)) exceeds your server's maximum. Try a lower value.", comment: "Error when Nightscout rejects the configured API entry limit")
+                        } else {
+                            self.providerIssue = String(localized: "Error from Nightscout: \(result.message)", comment: "Generic error from Nightscout server")
+                        }
                     }
                 } catch {
                     self.logger.error("Error parsing NS error response: \(String(describing: error), privacy: .public)")
@@ -395,6 +407,49 @@ class Nightscout: Provider, @unchecked Sendable {
         self.logger.debug("nightscout.verifyCredentials")
         await self.authenticate()
 
-        return self.isAuthenticated
+        if !self.isAuthenticated {
+            return false
+        }
+
+        // Test that the configured API limit is accepted by the server
+        let limitOK = await testAPILimit()
+        if !limitOK {
+            return false
+        }
+
+        return true
+    }
+
+    private func testAPILimit() async -> Bool {
+        let dateCutoff = Int(Date(timeIntervalSinceNow: -300).timeIntervalSince1970 * 1000)
+        let urlString = "\(baseURL)/api/v3/entries?sort%24desc=date&fields=identifier&date%24gte=\(dateCutoff)&limit=\(apiLimit)"
+
+        guard let url = URL(string: urlString) else { return false }
+
+        do {
+            var request = URLRequest(url: url, timeoutInterval: httpTimeout)
+            request.addValue("application/json", forHTTPHeaderField: "Accept")
+            if let token = self.auth?.token, !token.isEmpty {
+                request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            }
+            request.httpMethod = "GET"
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let res = response as? HTTPURLResponse, res.statusCode == 200 {
+                return true
+            }
+
+            if let errorResult = try? JSONDecoder().decode(NightscoutEntriesErrorResponse.self, from: data) {
+                self.logger.error("API limit test failed: \(errorResult.message, privacy: .public)")
+                await MainActor.run {
+                    self.providerIssue = String(localized: "The API Limit (\(self.apiLimit)) exceeds your server's maximum. Try a lower value.", comment: "Error when Nightscout rejects the configured API entry limit")
+                }
+            }
+            return false
+        } catch {
+            self.logger.error("API limit test error: \(String(describing: error), privacy: .public)")
+            return false
+        }
     }
 }

--- a/GlucoseBar/Settings/CGMSettingsView.swift
+++ b/GlucoseBar/Settings/CGMSettingsView.swift
@@ -68,6 +68,16 @@ struct CGMSettingsView: View {
                     Spacer()
                 }
 
+                HStack {
+                    Text("API Limit").frame(width: 130, alignment: .leading)
+                    Spacer()
+                    TextField("", value: $s.nsAPILimit, format: .number).textFieldStyle(RoundedBorderTextFieldStyle()).frame(width: 80)
+                }
+                HStack {
+                    Text("Maximum entries per request. Default is 1000, which is the standard Nightscout server limit (API3_MAX_LIMIT). Increase only if your server admin has raised this limit. Useful for longer time ranges (12h, 24h) on CGMs with frequent readings. The value is validated when you save or test the connection.").font(.footnote)
+                    Spacer()
+                }
+
                 VStack {
                     HStack {
                         Text("Enable AID Integration")
@@ -142,12 +152,13 @@ struct CGMSettingsView: View {
         @State var cgmCredentialsError: Bool = false
         @State var cgmCredentialsSuccess: Bool = false
         @State var validatedProvider: CGMProvider = .null
+        @State var validationError: String?
 
         @FocusState var nsSecretFailedValidationFocus: Bool
         @State var nsSecretFailedValidation: Bool = false
 
         var body: some View {
-            if let providerIssue = g.provider.providerIssue {
+            if let providerIssue = g.provider.providerIssue, !cgmCredentialsError {
                 Text("Provider issue: \(providerIssue)")
             }
             HStack {
@@ -181,20 +192,26 @@ struct CGMSettingsView: View {
                         isValidating = true
                         Task {
                             validatedProvider = s.cgmProvider
-                            g.reset(s)
                             let providerTest = await s.testCGMProvider()
 
-                            cgmCredentialsError = !providerTest
-                            cgmCredentialsSuccess = providerTest
+                            cgmCredentialsError = !providerTest.success
+                            cgmCredentialsSuccess = providerTest.success
+                            validationError = providerTest.error
                             isValidating = false
-                            s.validSettings = providerTest
+                            if providerTest.success {
+                                s.validSettings = true
+                            }
                         }
                     }) {
                         Text("Test Connection")
                     }.disabled(isValidating)
                 }
                 if !isValidating && cgmCredentialsError && s.cgmProvider == validatedProvider {
-                    Text("Invalid credentials or service unreachable").foregroundColor(.orange)
+                    if let error = validationError {
+                        Text(error).foregroundColor(.orange)
+                    } else {
+                        Text("Invalid credentials or service unreachable").foregroundColor(.orange)
+                    }
                     Image(systemName: "exclamationmark.triangle").foregroundColor(.orange)
                 }
                 if !isValidating && cgmCredentialsSuccess && s.cgmProvider == validatedProvider {
@@ -216,8 +233,26 @@ struct CGMSettingsView: View {
                         nsSecretFailedValidation = true
                         return
                     }
-                    s.save()
-                    g.reset(s)
+
+                    isValidating = true
+                    Task {
+                        validatedProvider = s.cgmProvider
+                        let providerTest = await s.testCGMProvider()
+
+                        if providerTest.success {
+                            cgmCredentialsError = false
+                            cgmCredentialsSuccess = true
+                            validationError = nil
+                            s.save()
+                            g.reset(s)
+                            s.validSettings = true
+                        } else {
+                            cgmCredentialsError = true
+                            cgmCredentialsSuccess = false
+                            validationError = providerTest.error
+                        }
+                        isValidating = false
+                    }
                 }.disabled(isValidating)
             }
         }

--- a/GlucoseBar/Settings/Settings.swift
+++ b/GlucoseBar/Settings/Settings.swift
@@ -23,6 +23,7 @@ class SettingsStore: ObservableObject, @unchecked Sendable {
     // Nightscout
     @Published var nsURL: String = "https://my.nightscout.site"
     @Published var nsSecret: String = "my-secret"
+    @Published var nsAPILimit: Int = 1000
 
     // Dexcom Share
     @Published var dxServer: DexcomServer = .ous
@@ -90,6 +91,10 @@ class SettingsStore: ObservableObject, @unchecked Sendable {
         // Nightscout
         self.nsURL = defaults.string(forKey: "nsURL") ?? "https://my.nightscout.site"
         self.nsSecret = defaults.string(forKey: "nsSecret") ?? ""
+        self.nsAPILimit = defaults.integer(forKey: "nsAPILimit")
+        if self.nsAPILimit == 0 {
+            self.nsAPILimit = 1000
+        }
 
         // Dexcom Share
         self.dxEmail = defaults.string(forKey: "dxEmail") ?? "your@email.com"
@@ -267,6 +272,7 @@ class SettingsStore: ObservableObject, @unchecked Sendable {
         // Nightscout
         defaults.set(self.nsURL, forKey: "nsURL")
         defaults.set(self.nsSecret, forKey: "nsSecret")
+        defaults.set(self.nsAPILimit, forKey: "nsAPILimit")
 
         // Dexcom Share
         defaults.set(self.dxServer.url, forKey: "dxServer")
@@ -331,14 +337,14 @@ class SettingsStore: ObservableObject, @unchecked Sendable {
         }
     }
 
-    func testCGMProvider() async -> Bool {
+    func testCGMProvider() async -> (success: Bool, error: String?) {
         var provider: Provider
         self.logger.notice("testCGMProvider: \(self.cgmProvider.presentable, privacy: .public)")
         switch self.cgmProvider {
         case .simulator:
             provider = Simulator("test auth")
         case .nightscout:
-            provider = Nightscout(baseURL: self.nsURL, token: self.nsSecret, aidEnabled: false)
+            provider = Nightscout(baseURL: self.nsURL, token: self.nsSecret, aidEnabled: false, apiLimit: self.nsAPILimit)
         case .dexcomshare:
             provider = DexcomShare(username: self.dxEmail, password: self.dxPassword, server: self.dxServer)
         default:
@@ -346,7 +352,8 @@ class SettingsStore: ObservableObject, @unchecked Sendable {
         }
 
         self.logger.notice("testCGMProvider calling verifyCredentials with provider: \(provider.type.presentable, privacy: .public)")
-        return await provider.verifyCredentials()
+        let result = await provider.verifyCredentials()
+        return (result, provider.providerIssue)
     }
 }
 


### PR DESCRIPTION
Hi! I ran into an issue where the chart time range options were limited for high-frequency CGMs. I dug into it and found the root cause, and I have a working implementation with a few related improvements. Built and tested locally — sharing the details below.

### The problem

The Nightscout provider fetches entries with a hardcoded `limit=288` and **no date filter**:

```
/api/v3/entries?sort$desc=date&fields=sgv,trend,direction,date,identifier&limit=288
```

288 entries is exactly 24 hours of data for a 5-minute CGM (288 × 5 min = 1440 min = 24h), so the chart works fine for that case. But for CGMs that report more frequently — for example, every 1 minute — 288 entries only covers about 4.8 hours. Since the available chart time ranges depend on how much data has been fetched, this means:

- **Longer time ranges simply don't appear** in the chart options. In my case, only 3h and 6h were available — 12h and 24h were missing entirely because there wasn't enough data to display them.
- The behavior is inconsistent across users: those with gaps in CGM readings may see more time range options (since the same number of entries spans a longer period), while users with continuous, complete data hit the ceiling sooner and get fewer options.

Here's what the chart looked like with the original `limit=288` — notice only the 3h and 6h options are available:

<details>
<summary>Before — 3 hours (only 3h and 6h available)</summary>

![Chart before fix — 3h view](https://github.com/user-attachments/assets/a5907800-7d65-473f-8740-8d5e17434a23)
</details>

<details>
<summary>Before — 6 hours (still only 3h and 6h available, no 12h or 24h)</summary>

![Chart before fix — 6h view](https://github.com/user-attachments/assets/8d87760e-1f4f-43e3-a841-fa33656e3320)
</details>

### What I changed and why

**1. Added a date filter to the API request**

Instead of relying solely on a count-based limit, the request now includes a date filter for the last 24 hours (`date$gte`). This ensures the query is aligned with the time ranges available in the chart UI, regardless of CGM frequency.

**2. Raised the default limit from 288 to 1000**

1000 is the default server-side maximum for Nightscout API v3 ([`API3_MAX_LIMIT`](https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/api3/swagger.yaml#L25-L26)). Combined with the date filter, this reliably covers 12 hours for 1-minute CGMs (12h × 60 = 720 entries) and the full 24 hours for standard 5-minute CGMs (288 entries). For CGMs that occasionally produce more than one reading per minute, the effective coverage may be somewhat less than 12 hours.

After this change, the 12h time range option appeared in my chart — a meaningful improvement over the previous 3h/6h only.

**3. Discovered the server-side limit constraint**

While testing with values above 1000, the Nightscout API v3 returned a `400` error: _"Parameter limit out of tolerance"_. The server enforces a maximum per request controlled by the [`API3_MAX_LIMIT`](https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/api3/swagger.yaml#L25-L26) environment variable (default: 1000).

This means for CGMs reporting every minute, full 24-hour coverage requires ~1440 entries — more than the default server limit. Users whose server administrators have raised `API3_MAX_LIMIT` should be able to take advantage of it.

**4. Added a configurable API Limit setting**

A new "API Limit" field in the Nightscout settings, defaulting to 1000. Users can increase it if their server supports a higher limit. The setting includes help text explaining what it does and when to change it.

### Validation and UX

This is where most of the care went. If a user sets a limit higher than their server allows and clicks Save, the app should not break. The implementation:

- **Validate before persisting**: Both "Save" and "Test Connection" now run a connection test (including an API limit test) _before_ writing to UserDefaults. If validation fails, the value is not saved and the app continues operating normally with the previous settings — no error state, no welcome screen.
- **`testAPILimit()`**: A new method in the Nightscout provider that makes a lightweight request using the configured limit. If the server rejects it, a clear error message is shown inline.
- **Clear, contextual error messages**: When the limit is rejected, the user sees _"The API Limit (1500) exceeds your server's maximum. Try a lower value."_ instead of the generic _"Invalid credentials or service unreachable"_.
- **Immediate feedback on save**: An immediate fetch is triggered after saving (instead of waiting for the next timer tick), so the user sees results or errors right away.

### Localization

All new user-facing strings have been added to `Localizable.xcstrings` with translations for the three supported languages (EN, DA, FR). Error messages in `Nightscout.swift` now use `String(localized:)` for proper localization support. DA and FR translations were generated with AI assistance and are marked as `needs_review`.

| String | EN | DA (`needs_review`) | FR (`needs_review`) |
|---|---|---|---|
| Label | API Limit | API-grænse | Limite API |
| Help text | Maximum entries per request... | Maksimalt antal poster... | Nombre maximum d'entrées... |
| Limit error | The API Limit (X) exceeds your server's maximum. Try a lower value. | API-grænsen (X) overstiger... | La limite API (X) dépasse le maximum... |
| Generic error | Error from Nightscout: (message) | Fejl fra Nightscout: (message) | Erreur de Nightscout : (message) |

### Files changed

| File | What changed |
|---|---|
| `Nightscout.swift` | Date filter on query, `apiLimit` parameter replacing hardcoded 288, `testAPILimit()`, localized error messages |
| `Settings.swift` | New `nsAPILimit` property (default 1000), load/save from UserDefaults, passed to test provider |
| `Glucose.swift` | Pass `apiLimit` when creating Nightscout provider (2 places), immediate fetch on `reset()` |
| `CGMSettingsView.swift` | API Limit field with help text, validate-before-save flow, error state management |
| `Localizable.xcstrings` | New entries with EN/DA/FR translations |

### Screenshots

**Chart — after the date filter and raised limit (1000), the 12h option now appears:**

<details>
<summary>After — 3 hours (now shows 3h, 6h, and 12h options)</summary>

![Chart after fix — 3h view](https://github.com/user-attachments/assets/bd8938cd-436f-440f-a6c3-4573394e3438)
</details>

<details>
<summary>After — 6 hours</summary>

![Chart after fix — 6h view](https://github.com/user-attachments/assets/2449d1a1-c6ca-4f83-ba9f-c58c17bb827a)
</details>

<details>
<summary>After — 12 hours (previously unavailable)</summary>

![Chart after fix — 12h view](https://github.com/user-attachments/assets/4fa1b318-4805-49f7-b2e5-d7a16f15f85c)
</details>

**Settings — API Limit configuration and validation:**

<details>
<summary>Successful save with default limit (Connection OK)</summary>

![Settings — connection OK with limit 1000](https://github.com/user-attachments/assets/6ecdb786-b995-49c6-ad10-c989e8e51e35)
</details>

<details>
<summary>Validation error when limit exceeds server maximum</summary>

![Settings — limit exceeds server maximum](https://github.com/user-attachments/assets/57a7a2e1-6f7d-47d3-add7-73dad4748828)
</details>

### How to test

1. Open Settings → Nightscout — confirm "API Limit" field appears with 1000
2. Leave at 1000, click Save — confirm chart loads normally and longer time ranges (e.g., 12h) now appear
3. Change to a value above your server's limit (e.g., 1500), click Save — confirm the error appears inline and the menu bar continues showing glucose data normally (no error state, no welcome screen)
4. Click Test Connection with the same high value — confirm the same error appears
5. Reset to 1000, click Save — confirm everything works as before

### Disclosure

I used AI assistance to analyze the codebase and implement these changes, including generating the DA and FR translations. I don't have prior experience with Swift or macOS development. Everything was built and tested locally in Xcode. Happy to adjust anything based on your feedback!
