### PR TITLE
Fix Dexcom bugs integration issues

### DIFF
--- a/GlucoseBar/Glucose.swift
+++ b/GlucoseBar/Glucose.swift
@@ -61,46 +61,59 @@ class Glucose: ObservableObject, Sendable {
     }
 
     func timerEventHandler() {
-        if self.settings.cgmProvider != self.provider.type {
-            self.setSettings(settings)
-        }
-        var shouldFetch: Bool = false
-        if !vs.isOnline {
-            self.logger.dlog("Aborting fetch because network is offline", category: "glucose", level: .default)
-            return
-        }
-
-        if self.provider.lastFetch.timeIntervalSinceNow <= -60 {
-            shouldFetch = true
-            self.logger.dlog("Glucose.timer initiating fetch because last fetch was over 1 minute ago", category: "glucose", level: .default)
-        }
-
-        if let entries = self.entries, let firstEntry = entries.first {
-            if firstEntry.date.timeIntervalSinceNow <= -300 && self.provider.lastFetch.timeIntervalSinceNow <= -10 {
-                shouldFetch = true
-                self.logger.dlog("Glucose.timer initiating fetch because latest reading is over 5 minutes old and last fetch was over 10 seconds ago", category: "glucose", level: .default)
+        // This handler is invoked from the background CGMQueue DispatchQueue, but
+        // Glucose is @MainActor-isolated. Hop to the main actor before touching any
+        // published or stored properties to eliminate the data race.
+        Task { @MainActor in
+            if self.settings.cgmProvider != self.provider.type {
+                self.setSettings(settings)
             }
-        }
+            var shouldFetch: Bool = false
+            if !vs.isOnline {
+                self.logger.dlog("Aborting fetch because network is offline", category: "glucose", level: .default)
+                return
+            }
 
-        if shouldFetch {
-            fetchQueue.async { [weak self] in
-                guard let self = self else { return }
-                Task {
-                    let alreadyFetching = await MainActor.run { self.isFetching }
-                    if alreadyFetching {
-                        await MainActor.run { self.logger.dlog("Skipping fetch - already in progress", category: "glucose", level: .debug) }
-                        return
-                    }
-                    await MainActor.run { self.isFetching = true }
-                    defer { Task { await MainActor.run { self.isFetching = false } } }
-                    await self.provider.fetch()
+            if self.provider.lastFetch.timeIntervalSinceNow <= -60 {
+                shouldFetch = true
+                self.logger.dlog("Glucose.timer initiating fetch because last fetch was over 1 minute ago", category: "glucose", level: .default)
+            }
+
+            if let entries = self.entries, let firstEntry = entries.first {
+                if firstEntry.date.timeIntervalSinceNow <= -300 && self.provider.lastFetch.timeIntervalSinceNow <= -10 {
+                    shouldFetch = true
+                    self.logger.dlog("Glucose.timer initiating fetch because latest reading is over 5 minutes old and last fetch was over 10 seconds ago", category: "glucose", level: .default)
                 }
             }
-        }
 
-        Task {
+            if shouldFetch {
+                fetchQueue.async { [weak self] in
+                    guard let self = self else { return }
+                    Task {
+                        let alreadyFetching = await MainActor.run { self.isFetching }
+                        if alreadyFetching {
+                            await MainActor.run { self.logger.dlog("Skipping fetch - already in progress", category: "glucose", level: .debug) }
+                            return
+                        }
+                        await MainActor.run { self.isFetching = true }
+                        defer { Task { await MainActor.run { self.isFetching = false } } }
+                        await self.provider.fetch()
+                    }
+                }
+            }
+
             self.getGlucose()
         }
+    }
+
+    /// Subscribe `providerCancellable` to the current provider's `objectWillChange`.
+    /// Must be called every time `self.provider` is replaced (both in `setSettings` and `reset`).
+    private func subscribeToProvider() {
+        self.providerCancellable = self.provider.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.getGlucose()
+            }
     }
 
     func reset(_ settings: SettingsStore) {
@@ -123,6 +136,10 @@ class Glucose: ObservableObject, Sendable {
         default:
             provider = Simulator("defaulted")
         }
+
+        // Re-subscribe to the new provider's changes (was missing before this fix,
+        // causing the menu bar to never update after a reset).
+        subscribeToProvider()
 
         timer = DispatchTimer(timeInterval: 15, queue: DispatchQueue(label: "tools.t1d.GlucoseBar.CGMQueue"))
         timer.suspend()
@@ -173,11 +190,7 @@ class Glucose: ObservableObject, Sendable {
             }
 
             // Subscribe to the newly assigned provider's changes
-            self.providerCancellable = self.provider.objectWillChange
-                .receive(on: DispatchQueue.main)
-                .sink { [weak self] _ in
-                    self?.getGlucose()
-                }
+            subscribeToProvider()
 
         }
 

--- a/GlucoseBar/MainAppView.swift
+++ b/GlucoseBar/MainAppView.swift
@@ -87,7 +87,7 @@ struct MainAppView: View {
 
     var body: some View {
         if g.error != "" && s.validSettings && vs.isOnline {
-            if g.provider.providerIssue == "Dexcom: No Data" {
+            if g.provider.providerIssue == DexcomShare.noDataIssue {
                 ScrollView {
                     Image(systemName: "bolt.trianglebadge.exclamationmark").resizable()
                         .frame(width: 96, height: 96).foregroundColor(.red).padding(.top, 5).padding(.horizontal)

--- a/GlucoseBar/MenuBarItems/GlucoseViewBuilder.swift
+++ b/GlucoseBar/MenuBarItems/GlucoseViewBuilder.swift
@@ -139,20 +139,20 @@ struct MenuBarView: View {
                         self.cachedZenImage = generateZenModeImage()
                     }
                 }
-            }.onReceive(g.provider.objectWillChange) { _ in
+            }            .onReceive(g.provider.objectWillChange) { _ in
                 let now = Date()
                 if now.timeIntervalSince(lastUpdateTime) > 1.0 {
                     lastUpdateTime = now
                     Task {
                         await MainActor.run {
-                            self.cachedMenuImage = generateMenuBarImage()
+                            self.cachedZenImage = generateZenModeImage()
                         }
                     }
                 }
             }.onReceive(s.$menuBarItemSpacing) { _ in
                 Task {
                     await MainActor.run {
-                        self.cachedMenuImage = generateMenuBarImage()
+                        self.cachedZenImage = generateZenModeImage()
                     }
                 }
             }

--- a/GlucoseBar/Providers/DexcomShare/DexcomShare.swift
+++ b/GlucoseBar/Providers/DexcomShare/DexcomShare.swift
@@ -31,17 +31,29 @@ public enum DexcomServer: String, CaseIterable, Identifiable {
 
 class DexcomShare: Provider, @unchecked Sendable {
 
-    private var isAuthenticated = false
     private var accountID: String = ""
     private var sessionID: String = ""
     public var validSettings: Bool = true
     public var settingsError: String = ""
+    /// Count of consecutive credential-level auth failures (4xx responses).
+    /// Only incremented for definitive credential errors, not transient server
+    /// errors (5xx), so a brief Dexcom outage cannot permanently lock the provider.
     private var unsuccessfulAuthAttempts = 0
+    /// Timestamp of the last credential failure. Allows the lockout to be
+    /// automatically cleared after a cooling-off period even without a settings reset.
+    private var lastAuthFailureDate: Date? = nil
+    /// How long the lock-out lasts before being automatically retried (30 minutes).
+    private let authLockoutDuration: TimeInterval = 30 * 60
 
     @MainActor
     func setProviderIssue(_ value: String?) {
         self.providerIssue = value
     }
+
+    /// Sentinel string used when Dexcom returns a valid 200 response but with no
+    /// glucose entries (e.g. sensor warm-up, signal loss). Referenced by views to
+    /// show a tailored "No data" UI rather than a generic error.
+    static let noDataIssue = "Dexcom: No Data"
 
     // Hardcoded value found in https://github.com/gagebenne/pydexcom
     private let dexcomApplicationID = "d89443d2-327c-4a6f-89e5-496bbb0317db"
@@ -103,16 +115,29 @@ class DexcomShare: Provider, @unchecked Sendable {
 
     override internal func fetch() async {
         logger.dlog("DexcomShare.fetch", category: "dexcomshare", level: .debug)
+
+        // Auto-reset the lockout after the cooling-off period so transient outages
+        // don't require the user to manually reset settings.
         if unsuccessfulAuthAttempts > 5 {
-            self.providerIssue = "Unable to connect to Dexcom Share after 5 attempts. Please check your credentials and if Dexcom is asking to send a code to your email or phone, please go through that flow on your device."
-            return
+            if let failDate = lastAuthFailureDate,
+               Date().timeIntervalSince(failDate) > authLockoutDuration {
+                logger.dlog("Auth lockout expired, resetting counter", category: "dexcomshare", level: .default)
+                unsuccessfulAuthAttempts = 0
+                lastAuthFailureDate = nil
+                accountID = ""
+                sessionID = ""
+            } else {
+                self.providerIssue = "Unable to connect to Dexcom Share after 5 attempts. Please check your credentials and if Dexcom is asking to send a code to your email or phone, please go through that flow on your device."
+                return
+            }
         }
 
         if !isAuthValid() {
             logger.dlog("calling authenticate from fetch", category: "dexcomshare", level: .debug)
             await authenticate()
-            await fetch()
-            return
+            // Only proceed if authentication actually succeeded; do not recurse
+            // to avoid cascading network calls when auth fails repeatedly.
+            guard isAuthValid() else { return }
         }
 
         await self.setProviderIssue(nil)
@@ -146,10 +171,14 @@ class DexcomShare: Provider, @unchecked Sendable {
                 do {
                     let result = try JSONDecoder().decode(DexcomShareErrorResponse.self, from: data)
 
-                    // If auth error, clear auth data and re-fetch
+                    // If session expired, clear auth data and re-authenticate inline
+                    // (one level only — no recursive fetch to avoid cascading calls).
                     if result.Code == "SessionIdNotFound" || result.Code == "SessionNotValid" {
                         self.accountID = ""
                         self.sessionID = ""
+                        await authenticate()
+                        guard isAuthValid() else { return }
+                        // Re-attempt the data fetch now that we have a fresh session.
                         await self.fetch()
                         return
                     }
@@ -178,9 +207,12 @@ class DexcomShare: Provider, @unchecked Sendable {
 
                     let newEntries = self.dexcomEntriesToGlucoseEntries(input: result, previous: previous)
                     if newEntries.isEmpty {
-                        await self.setProviderIssue("Dexcom: No Data")
+                        await self.setProviderIssue(DexcomShare.noDataIssue)
+                        // Do NOT call setGlucoseEntries([]) — preserve the existing
+                        // cache so the chart and last-known glucose remain visible.
+                    } else {
+                        self.setGlucoseEntries(newEntries)
                     }
-                    self.setGlucoseEntries(newEntries)
                     self.lastFetch = Date()
                 } catch DecodingError.dataCorrupted(_) {
                     await self.setProviderIssue(String(localized: "Unable to read data from Dexcom Share: Data corrupted."))
@@ -204,9 +236,11 @@ class DexcomShare: Provider, @unchecked Sendable {
     }
 
     private func dexcomEntriesToGlucoseEntries(input: [DXEntriesResult], previous: GlucoseEntry?) -> [GlucoseEntry] {
+        // Dexcom returns entries newest-first.
+        // To compute changeRate for entry[i] we need entry[i+1] (the older neighbour),
+        // which we can look up by index once we have the raw value array.
         var ge: [GlucoseEntry] = []
-        var lastValue: Int64 = 0
-        input.forEach { dxEntry in
+        for (i, dxEntry) in input.enumerated() {
             var wt = dxEntry.WT.replacingOccurrences(of: "Date(", with: "")
             wt = wt.replacingOccurrences(of: ")", with: "")
             let date = Date(timeIntervalSince1970: (Double(wt)! / 1000))
@@ -216,15 +250,12 @@ class DexcomShare: Provider, @unchecked Sendable {
                 trend = GlucoseEntry.GlucoseTrend(direction: dxEntry.Trend)
             }
 
-            var changeRate = 0.0
-            if lastValue > 0 {
-                changeRate = Double(lastValue - dxEntry.Value)
-            }
+            // positive = rising, negative = falling; 0 for the oldest entry (no prior reference).
+            let olderValue = i + 1 < input.count ? Double(input[i + 1].Value) : nil
+            let changeRate = olderValue.map { Double(dxEntry.Value) - $0 } ?? 0.0
 
             let entry = GlucoseEntry(glucose: Double(dxEntry.Value), date: date, glucoseType: .sensor, trend: trend, changeRate: changeRate)
             ge.append(entry)
-
-            lastValue = dxEntry.Value
         }
 
         return ge
@@ -274,7 +305,13 @@ class DexcomShare: Provider, @unchecked Sendable {
                 return
             }
             if res.statusCode > 299 {
-                unsuccessfulAuthAttempts += 1
+                // Only count 4xx responses as credential failures.
+                // 5xx responses are transient server errors and must not
+                // count toward the lockout threshold.
+                if res.statusCode < 500 {
+                    unsuccessfulAuthAttempts += 1
+                    lastAuthFailureDate = Date()
+                }
                 var providerError: String? = nil
                 let responseString = String(data: data, encoding: .utf8) ?? "Unable to decode response"
                 self.logger.dlog("\(responseString)", category: "dexcomshare", level: .error)
@@ -347,7 +384,11 @@ class DexcomShare: Provider, @unchecked Sendable {
                 return
             }
             if res.statusCode > 299 {
-                unsuccessfulAuthAttempts += 1
+                // Only count 4xx responses as credential failures (not transient 5xx).
+                if res.statusCode < 500 {
+                    unsuccessfulAuthAttempts += 1
+                    lastAuthFailureDate = Date()
+                }
                 var providerError = ""
                 let responseString = String(data: data, encoding: .utf8) ?? "Unable to decode response"
                 self.logger.dlog("\(responseString)", category: "dexcomshare", level: .error)

--- a/GlucoseBar/SourceMenuBarLabel.swift
+++ b/GlucoseBar/SourceMenuBarLabel.swift
@@ -37,7 +37,7 @@ struct SourceMenuBarLabel: View {
                     }
                 }
             } else if g.error != "" && s.validSettings && vs.isOnline {
-                if g.provider.providerIssue == "Dexcom: No Data" {
+                if g.provider.providerIssue == DexcomShare.noDataIssue {
                     Label(
                         title: { Text(" No data") },
                         icon: { Image(systemName: "bolt.trianglebadge.exclamationmark") }


### PR DESCRIPTION
Claude helped me find a bunch of issues in the Dexcom integration. Below is a list of fixes applied.

- providerCancellable was not re-subscribed after reset(), so the menu bar never updated when the user changed provider settings. Extract subscribeToProvider() helper and call it from both setSettings() and reset().
- fetch() called itself recursively after a failed authenticate(), stacking up to 5 cascading network calls before the guard fired. Replace the recursive tail-call with a guard-and-return pattern.
- unsuccessfulAuthAttempts incremented on any HTTP >= 300, including transient Dexcom 5xx server errors. After 5 transient failures the provider was permanently locked until a manual settings reset. Fix: only count 4xx (credential) failures; add a 30-minute automatic lockout expiry via lastAuthFailureDate.
- timerEventHandler() was called from the CGMQueue background thread but read @MainActor-isolated properties directly. Wrap the entire handler body in a task.
- An empty Dexcom 200 response called setGlucoseEntries([]), wiping cached readings and the chart. Preserve existing entries; only set providerIssue without clearing the cache.
- In zen mode, objectWillChange and menuBarItemSpacing receivers updated cachedMenuImage instead of cachedZenImage.
- Remove dead isAuthenticated field (set but never read).
- Replace raw "Dexcom: No Data" string literal with DexcomShare.noDataIssue static constant used in all three files.
- Fix changeRate computation in dexcomEntriesToGlucoseEntries; was storing the wrong sign on the wrong entry due to newest-first iteration.